### PR TITLE
Fixed java example

### DIFF
--- a/examples/java/build.xml
+++ b/examples/java/build.xml
@@ -10,7 +10,7 @@
     <mkdir dir="target/junit-report"/>
     <taskdef name="cucumber" classname="cuke4duke.ant.CucumberTask" classpathref="compile.classpath"/>
     <cucumber
-            args="--verbose --require target/test-classes --color --format pretty --format junit --out target/junit-report features"
+            args="--verbose --require target/test-classes --require src/test/ruby --color --format pretty --format junit --out target/junit-report features"
             objectFactory="pico">
       <classpath>
         <pathelement location="target/test-classes"/>


### PR DESCRIPTION
Hi Aslak,

The cuke4duke Java example was failing because it depended on the Ruby hook but the Ruby step def directory was never required in the cucumber target. I've fixed it in this branch.

Richard 
