### PR TITLE
Fixes broken build.

### DIFF
--- a/examples/java/build.xml
+++ b/examples/java/build.xml
@@ -24,7 +24,7 @@
 
   <target name="-install-gems" depends="-define-paths" if="gems">
     <taskdef name="gem" classname="cuke4duke.ant.GemTask" classpathref="compile.classpath"/>
-    <gem args="install cuke4duke --version 0.4.2"/>
+    <gem args="install cuke4duke --version 0.4.3"/>
   </target>
 
   <target name="-define-paths" depends="-download-jars">

--- a/examples/java/ivy.xml
+++ b/examples/java/ivy.xml
@@ -1,7 +1,7 @@
 <ivy-module version="2.0">
   <info organisation="cukes.info" module="java-example"/>
   <dependencies>
-    <dependency org="cuke4duke" name="cuke4duke" rev="0.4.2"/>
+    <dependency org="cuke4duke" name="cuke4duke" rev="0.4.3"/>
     <dependency org="org.jruby" name="jruby-complete" rev="1.5.3" transitive="false"/>
     <dependency org="org.picocontainer" name="picocontainer" rev="2.11.2"/>
     <dependency org="junit" name="junit" rev="4.8.1"/>

--- a/examples/java/pom.xml
+++ b/examples/java/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>cuke4duke</groupId>
   <artifactId>cuke4duke-java-example</artifactId>
-  <version>0.4.2</version>
+  <version>0.4.3</version>
   <packaging>jar</packaging>
   <name>Cuke4Duke: Java Example</name>
 
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>cuke4duke</groupId>
       <artifactId>cuke4duke</artifactId>
-      <version>0.4.2</version>
+      <version>0.4.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -89,7 +89,7 @@
       <plugin>
         <groupId>cuke4duke</groupId>
         <artifactId>cuke4duke-maven-plugin</artifactId>
-        <version>0.4.2</version>
+        <version>0.4.3</version>
         <configuration>
           <jvmArgs>
             <!-- Debugging. See http://wiki.github.com/aslakhellesoy/cuke4duke/debug-cuke4duke-steps -->
@@ -121,7 +121,7 @@
             <cucumberArg>${basedir}/src/test/ruby</cucumberArg>
           </cucumberArgs>
           <gems>
-            <gem>install cuke4duke --version 0.4.2</gem>
+            <gem>install cuke4duke --version 0.4.3</gem>
           </gems>
         </configuration>
         <executions>


### PR DESCRIPTION
Fresh clone of cuke4duke build fails with an unsatisfied dependency in maven from url:

Downloading: http://cukes.info/maven/cuke4duke/cuke4duke-maven-plugin/0.4.2/cuke4duke-maven-plugin-0.4.2.pom
[WARNING] The POM for cuke4duke:cuke4duke-maven-plugin:jar:0.4.2 is missing, no dependency information available
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] Cuke4Duke: Parent ................................. SUCCESS [0.887s]
[INFO] Cuke4Duke: Core ................................... SUCCESS [45.280s]
[INFO] Cuke4Duke: Maven Plugin ........................... SUCCESS [2.509s]
[INFO] Cuke4Duke: EJB3 Example ........................... SUCCESS [41.349s]
[INFO] Cuke4Duke: Java Example ........................... FAILURE [0.300s]

Updaing the version of the cuke4duke-maven plugin from 0.4.2 -> 0.4.3 allows a fresh clone from git to successfully build.

Oliver
