### PR TITLE
Add all Ant tasks to antlib.xml

### DIFF
--- a/cuke4duke/src/main/resources/cuke4duke/ant/antlib.xml
+++ b/cuke4duke/src/main/resources/cuke4duke/ant/antlib.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0"?>
 <antlib xmlns:current="ant:current">
    <taskdef name="gem" classname="cuke4duke.ant.GemTask"/>
+   <taskdef name="cucumber" classname="cuke4duke.ant.CucumberTask"/>
+   <taskdef name="jruby" classname="cuke4duke.ant.JRubyTask"/>
 </antlib>


### PR DESCRIPTION
The antlib.xml does not declare all the Ant tasks (specifically CucumberTask and JRubyTask are missing).   Added them for consistency and completeness of the antlib.
