### PR TITLE
Fixed optional capture groups in step definitions

### DIFF
--- a/cuke4duke/src/main/java/cuke4duke/internal/language/StepArgument.java
+++ b/cuke4duke/src/main/java/cuke4duke/internal/language/StepArgument.java
@@ -7,8 +7,13 @@ public class StepArgument {
     private final int byteOffset;
 
     public StepArgument(String val, int charOffset, String stepName) throws UnsupportedEncodingException {
-        this.byteOffset = stepName.substring(0, charOffset).getBytes("UTF-8").length;
-        this.val = val;
+        if (charOffset != -1) {
+            this.byteOffset = stepName.substring(0, charOffset).getBytes("UTF-8").length;
+            this.val = val;
+        } else {
+            this.byteOffset = -1;
+            this.val = "";
+        }
     }
 
     public String getVal() {

--- a/cuke4duke/src/test/java/cuke4duke/internal/language/JdkPatternArgumentMatcherTest.java
+++ b/cuke4duke/src/test/java/cuke4duke/internal/language/JdkPatternArgumentMatcherTest.java
@@ -29,6 +29,12 @@ public class JdkPatternArgumentMatcherTest {
         assertVariables("Jæ (.+) ålsker (.+) lændet", "Jæ vø ålsker døtte lændet", "vø", 4, "døtte", 16);
     }
 
+    @Test
+    public void shouldDealWithOptionalCaptureGroups() throws UnsupportedEncodingException {
+        assertVariables("It should( not)? be ok (.+)", "It should be ok dude", "", -1, "dude", 16);
+        assertVariables("It should( still)? be ok (.+)", "It should still be ok mate", " still", 9, "mate", 22);
+    }
+
     private void assertVariables(String regex, String string, String v1, int pos1, String v2, int pos2) throws UnsupportedEncodingException {
         List<StepArgument> args = JdkPatternArgumentMatcher.argumentsFrom(Pattern.compile(regex), string);
         assertEquals(2, args.size());


### PR DESCRIPTION
Hi,

I have resolved an issue with cuke4duke not handling optional capture groups correctly in step definitions.

You can reproduce this bug using the following step definition

``` java
@Then("^I am( not)? handling optional capture groups correctly$")
public void handlingOptionalCaptureGroups(String not) {
    ...
}
```

along with the feature step below

```
Then I am handling optional capture groups correctly
```

Basically we get a `String index out of range` exception when the optional parameter is not provided (matching with an empty string).

This patch makes the `String` parameter available and empty in this case, as expected.

Unit tests are provided as well and the patch comes in a topic branch, to easily accommodate any further changes before merging.

Hope to see this pulled soon :D

Thanks,
_Luca Bernardo Ciddio_
