### PR TITLE
Escape the ~ in multiline RVM/none RVM instructions.

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -14,18 +14,18 @@ With JRuby installed - bootstrap your environment by installing some gems:
 
 Using RVM:
 <pre>
-mkdir -p ~/.m2/repository/.jruby
+@mkdir -p ~/.m2/repository/.jruby
 GEM_HOME=~/.m2/repository/.jruby GEM_PATH=~/.m2/repository/.jruby gem install bundler
 GEM_HOME=~/.m2/repository/.jruby GEM_PATH=~/.m2/repository/.jruby ~/.m2/repository/.jruby/bin/bundle install
-GEM_HOME=~/.m2/repository/.jruby GEM_PATH=~/.m2/repository/.jruby ~/.m2/repository/.jruby/bin/rake install
+GEM_HOME=~/.m2/repository/.jruby GEM_PATH=~/.m2/repository/.jruby ~/.m2/repository/.jruby/bin/rake install@
 </pre>
 
 Not using RVM:
 <pre>
-mkdir -p ~/.m2/repository/.jruby
+@mkdir -p ~/.m2/repository/.jruby
 GEM_HOME=~/.m2/repository/.jruby GEM_PATH=~/.m2/repository/.jruby jruby -S gem install bundler
 GEM_HOME=~/.m2/repository/.jruby GEM_PATH=~/.m2/repository/.jruby jruby -S bundle install
-GEM_HOME=~/.m2/repository/.jruby GEM_PATH=~/.m2/repository/.jruby jruby -S rake install
+GEM_HOME=~/.m2/repository/.jruby GEM_PATH=~/.m2/repository/.jruby jruby -S rake install@
 </pre>
 
 With the gems installed, build the whole shebang (including the examples):


### PR DESCRIPTION
- for some reason the <pre></pre> was not escaping the ~ and causing the ~ (meant for home directory) to format as super script.
  - this caused copy/paste into the terminal to fail.
